### PR TITLE
Added to ensure that bufferSize is larger than compressionOverhead in…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/SnappyCodec.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/SnappyCodec.java
@@ -87,7 +87,7 @@ public class SnappyCodec implements Configurable, CompressionCodec, DirectDecomp
         CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY,
         CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT);
 
-    int compressionOverhead = (bufferSize / 6) + 32;
+    int compressionOverhead = Math.min((bufferSize / 6) + 32, bufferSize);
 
     return new BlockCompressorStream(out, compressor, bufferSize,
         compressionOverhead);


### PR DESCRIPTION
… SnappyCodec

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR modifies the `createOutputStream` method in class `SnappyCodec` in order to ensure that `bufferSize` (configuration parameter name `io.compression.codec.snappy.buffersize`) is always larger than `compressionOverhead`. 

Otherwise, in `BlockCompressorStream.java`, the parameter `MAX_INPUT_SIZE` will be negative, and causing an `IndexOutOfBoundException` later. 

### How was this patch tested?

(1) Set `io.compression.codec.snappy.buffersize` to an integer value smaller than 38, e.g., `7 `

(2) Run a simple test that exercises this parameter, e.g. `org.apache.hadoop.io.compress.TestCodec#testSnappyMapFile`

The test will pass, instead of throwing an `IndexOutOfBoundException`.


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?